### PR TITLE
python: custom interactive interpreter setup

### DIFF
--- a/install-win.conf.yaml
+++ b/install-win.conf.yaml
@@ -11,6 +11,7 @@
       path: git/*
     ~/.config/vim: vim
     ~/.config/nvim: vim
+    ~/.config/python: python
     # add a convenient symlink to the dotfiles
     ~/.dotfiles: ""
     ~/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState:

--- a/python/startup.py
+++ b/python/startup.py
@@ -1,66 +1,144 @@
-"""Customize Python Startup
+"""Customize Python Interactive Console
 
-The bulk of this startup customization is copied from the default interactive
-hook set at site.rlcompleter.register_readline. It is customized to respect
-PYTHONHISTFILE and XDG_DATA_HOME if set for placing the history file.
+This python startup customization will try to enable certain 3rd party
+features if they are available, across all platforms.
+
+  * If the `rich` library is available, some of its features will be enabled
+    such as the pretty printer, traceback printing, and inspect function
+  * If `ipython` is available, it will be used as the interpreter
+  * If `prompt_toolkit` is available, it will be used as the interpreter
+  * Otherwise, if readline is available it will be used
+
+Sources/Inspiration:
+    - site.rlcompleter.register_readline
+    - prompt_toolkit help documentation / samples
 """
-import sys
 
+LOCALS = {}
+# Use the rich library if available, make rich.inspect available
+try:
+    from rich import pretty, inspect, traceback as tb
+    pretty.install()
+    tb.install(show_locals=False)
+    LOCALS['inspect'] = inspect
+    del tb, pretty
+except ImportError:
+    pass
 
-def custom_register_readline():
-    try:
-        import readline
-        import rlcompleter  # noqa: F401
-    except ImportError:
-        return
-    import atexit
+# Use IPython as interactive interpreter if available
+try:
+    import IPython
     import os
 
-    # Reading the initialization (config) file may not be enough to set a
-    # completion key, so we set one first and then read the file.
-    readline_doc = getattr(readline, "__doc__", "")
-    if readline_doc is not None and "libedit" in readline_doc:
-        readline.parse_and_bind("bind ^I rl_complete")
-    else:
-        readline.parse_and_bind("tab: complete")
+    os.environ["PYTHONSTARTUP"] = ""
+    IPython.start_ipython(user_ns=LOCALS)
+    raise SystemExit
+except ImportError:
+    pass
 
-    try:
-        readline.read_init_file()
-    except OSError:
-        # An OSError here could have many causes, but the most likely one
-        # is that there's no .inputrc file (or .editrc file in the case of
-        # Mac OS X + libedit) in the expected location.  In that case, we
-        # want to ignore the exception.
-        pass
+class CustomInitialization:
+    @staticmethod
+    def init_histfile():
+        import os
+        from pathlib import Path
 
-    # Adapted from https://bugs.python.org/msg318437
-    if "PYTHONHISTFILE" in os.environ:
-        history = os.path.expanduser(os.environ["PYTHONHISTFILE"])
-    elif "XDG_DATA_HOME" in os.environ:
-        history = os.path.join(os.path.expanduser(os.environ["XDG_DATA_HOME"]),
-                               "python", "python_history")
-    else:
-        history = os.path.join(os.path.expanduser("~"), ".python_history")
+        # Adapted from https://bugs.python.org/msg318437
+        if "PYTHONHISTFILE" in os.environ:
+            hist = os.environ["PYTHONHISTFILE"]
+        elif "XDG_DATA_HOME" in os.environ:
+            hist = Path(os.environ["XDG_DATA_HOME"]) / "python" / "python_history"
+        else:
+            hist = Path("~/.python_history")
+        
+        history = Path(hist).expanduser().absolute()
+        history.parent.mkdir(parents=True, exist_ok=True)
+        history.touch(exist_ok=True)
 
-    history = os.path.abspath(history)
-    _dir, _ = os.path.split(history)
-    os.makedirs(_dir, exist_ok=True)
-
-    try:
-        readline.read_history_file(history)
-    except IOError:
-        pass
-
-    def write_history():
+        return history
+    
+    @staticmethod
+    def init_readline_completion():
         try:
-            readline.write_history_file(history)
+            import readline
+            import rlcompleter  # noqa: F401
+        except ImportError:
+            return
+
+        # Reading the initialization (config) file may not be enough to set a
+        # completion key, so we set one first and then read the file.
+        readline_doc = getattr(readline, "__doc__", "")
+        if readline_doc is not None and "libedit" in readline_doc:
+            readline.parse_and_bind("bind ^I rl_complete")
+        else:
+            readline.parse_and_bind("tab: complete")
+
+        try:
+            readline.read_init_file()
         except OSError:
-            # bpo-19891, bpo-41193: Home directory does not exist
-            # or is not writable, or the filesystem is read-only.
+            # An OSError here could have many causes, but the most likely one
+            # is that there's no .inputrc file (or .editrc file in the case of
+            # Mac OS X + libedit) in the expected location.  In that case, we
+            # want to ignore the exception.
             pass
 
-    atexit.register(write_history)
+    @staticmethod
+    def init_readline_history(cls):
+        try:
+            import readline
+        except ImportError:
+            return
+        import atexit
+        
+        cls.init_readline_completion()
+        history = cls.init_histfile()
+        readline.read_history_file(history)
+
+        def write_history():
+            try:
+                readline.write_history_file(history)
+            except OSError:
+                # bpo-19891, bpo-41193: Home directory does not exist
+                # or is not writable, or the filesystem is read-only.
+                pass
+
+        atexit.register(write_history)
 
 
-sys.__interactivehook__ = custom_register_readline
-del sys, custom_register_readline
+# The following checks for prompt_toolkit / pygments, to use as an
+# alternative to readline.
+try:
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.history import FileHistory
+    from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+    try:
+        from pygments.lexers.python import PythonLexer
+        from pygments.styles import get_style_by_name
+        from prompt_toolkit.lexers import PygmentsLexer
+        from prompt_toolkit.styles.pygments import style_from_pygments_cls
+        style = style_from_pygments_cls(get_style_by_name('onedark'))
+        lexer = PygmentsLexer(PythonLexer)
+    except ImportError:
+        lexer = None
+        style = None
+    from functools import partial
+    import code
+
+    history = CustomInitialization.init_histfile()
+    session = PromptSession(history=FileHistory(history))
+    custom_prompt = partial(
+        session.prompt,
+        auto_suggest=AutoSuggestFromHistory(),
+        lexer=lexer,
+        style=style,
+        include_default_pygments_style=False
+    )
+    code.interact(readfunc=custom_prompt, banner="", locals=LOCALS)
+    raise SystemExit
+except ImportError:
+    pass
+
+import sys  # noqa
+
+
+sys.__interactivehook__ = CustomInitialization.init_readline_history
+del sys, LOCALS, CustomInitialization

--- a/python/startup.py
+++ b/python/startup.py
@@ -13,6 +13,7 @@ Sources/Inspiration:
     - site.rlcompleter.register_readline
     - prompt_toolkit help documentation / samples
 """
+# pyright: reportMissingImports=false
 
 LOCALS = {}
 # Use the rich library if available, make rich.inspect available
@@ -36,6 +37,7 @@ try:
 except ImportError:
     pass
 
+
 class CustomInitialization:
     @staticmethod
     def init_histfile():
@@ -46,16 +48,17 @@ class CustomInitialization:
         if "PYTHONHISTFILE" in os.environ:
             hist = os.environ["PYTHONHISTFILE"]
         elif "XDG_DATA_HOME" in os.environ:
-            hist = Path(os.environ["XDG_DATA_HOME"]) / "python" / "python_history"
+            hist = os.environ["XDG_DATA_HOME"] + "/python/python_history"
         else:
-            hist = Path("~/.python_history")
-        
+            hist = "~/.python_history"
+
         history = Path(hist).expanduser().absolute()
         history.parent.mkdir(parents=True, exist_ok=True)
         history.touch(exist_ok=True)
+        print(f"History file: {history}")
 
         return history
-    
+
     @staticmethod
     def init_readline_completion():
         try:
@@ -81,14 +84,14 @@ class CustomInitialization:
             # want to ignore the exception.
             pass
 
-    @staticmethod
+    @classmethod
     def init_readline_history(cls):
         try:
             import readline
         except ImportError:
             return
         import atexit
-        
+
         cls.init_readline_completion()
         history = cls.init_histfile()
         readline.read_history_file(history)
@@ -115,7 +118,7 @@ try:
         from pygments.styles import get_style_by_name
         from prompt_toolkit.lexers import PygmentsLexer
         from prompt_toolkit.styles.pygments import style_from_pygments_cls
-        style = style_from_pygments_cls(get_style_by_name('onedark'))
+        style = style_from_pygments_cls(get_style_by_name('one-dark'))
         lexer = PygmentsLexer(PythonLexer)
     except ImportError:
         lexer = None
@@ -132,7 +135,7 @@ try:
         style=style,
         include_default_pygments_style=False
     )
-    code.interact(readfunc=custom_prompt, banner="", locals=LOCALS)
+    code.interact(readfunc=custom_prompt, banner="", local=LOCALS)
     raise SystemExit
 except ImportError:
     pass

--- a/python/startup.py
+++ b/python/startup.py
@@ -55,8 +55,6 @@ class CustomInitialization:
         history = Path(hist).expanduser().absolute()
         history.parent.mkdir(parents=True, exist_ok=True)
         history.touch(exist_ok=True)
-        print(f"History file: {history}")
-
         return history
 
     @staticmethod

--- a/setup_env_win.ps1
+++ b/setup_env_win.ps1
@@ -21,6 +21,9 @@ $envs = @{
     # Configure pipenv to create virtual env's inside of the project directory
     PIPENV_VENV_IN_PROJECT=1
 
+    # Custom Python startup file for interactive interpreter
+    PYTHONSTARTUP = Join-Path $Env:UserProfile .config python startup.py
+
     # I prefer my user site-packages to more closely match the location seen on
     # linux: ~/.local, instead of %APPDATA%/Roaming/Python/Python310
     PYTHONUSERBASE = Join-Path $Env:UserProfile .local Python


### PR DESCRIPTION
Sets a custom startup file for python interactive interpreter, with the following goals:

- Enable history on all OS's
- Respect XDG standards/environment variables for history location
- If rich is available, add inspect to the default namespace, turn on pretty
- If prompt_toolkit/pygments is available, enable syntax highlighting

Note: Windows doesn't have readline and the pyreadline3 library is buggy, so prompt-toolkit is required for proper history support.